### PR TITLE
Maintenance update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-- 2.3.8
-- 2.4.5
-- 2.5.3
-- 2.6.0
+- 2.4.9
+- 2.5.6
+- 2.6.5
 - 2.7.0
 env:
 - ACTIVESUPPORT_VERSION='> 5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ rvm:
 - 2.4.5
 - 2.5.3
 - 2.6.0
+- 2.7.0
 env:
 - ACTIVESUPPORT_VERSION='> 5'
 - ACTIVESUPPORT_VERSION=4.2.11
 
-before_install: gem install bundler -v 1.16.1
+before_install: gem install bundler
 matrix:
   fast_finish: true
 script:

--- a/paypal_client.gemspec
+++ b/paypal_client.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'faraday_middleware', '~> 0.12'
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 

--- a/paypal_client.gemspec
+++ b/paypal_client.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware', '~> 0.12'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
   spec.required_ruby_version = '>= 2.3'


### PR DESCRIPTION
* Update rake gem in response to: https://github.com/advisories/GHSA-jppv-gw3r-w3q8
* Update build matrix
* Do not build for ruby 2.3.x since this version is end-of-life
* Remove bundler version constraint from gemspec