### PR TITLE
Update Faraday dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.1 - 27-05-2021
+* Update faraday dependencies
+
 ## 0.4.0 - 02-03-2020
 * [#4] (https://github.com/dennisvdvliet/paypal_client/pull/4) Maintenance update
     - Update rake gem in response to: https://github.com/advisories/GHSA-jppv-gw3r-w3q8

--- a/lib/paypal_client/version.rb
+++ b/lib/paypal_client/version.rb
@@ -1,3 +1,3 @@
 module PaypalClient
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end

--- a/paypal_client.gemspec
+++ b/paypal_client.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', "#{(ENV['ACTIVESUPPORT_VERSION'] || '> 4.2.8')}"
-  spec.add_dependency 'faraday', '~> 0.15'
-  spec.add_dependency 'faraday_middleware', '~> 0.12'
+  spec.add_dependency 'faraday', '~> 1.4'
+  spec.add_dependency 'faraday_middleware', '~> 1'
 
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Version 1 of Faraday has been out for quite some time now.  There are a growing number of other dependencies which will not be able to be updated if this gem continues to use faraday 0.x.x